### PR TITLE
Dependencies not required in config

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -58,7 +58,6 @@ class Validator extends AbstractValidator
     {
         return array(
             Cfg::K_KEY,
-            Cfg::K_DEPENDENCIES
         );
     }
 }


### PR DESCRIPTION
The dependencies are not required to be specified in module configuration. It can be omitted by modules to signify a lack of dependencies.